### PR TITLE
Fix Java version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/jvilk/locate-java-home.git"
   },
   "scripts": {
-    "prepare": "tsc && tsc -p tsconfig.es6.json && javac -source 1.6 -target 1.6 ts/test/fixtures/EnvironmentTest.java",
+    "prepare": "tsc && tsc -p tsconfig.es6.json && javac -source 1.7 -target 1.7 ts/test/fixtures/EnvironmentTest.java",
     "test": "npm run prepare && mocha js/es5/test --timeout 30000"
   },
   "bin": {


### PR DESCRIPTION
`npm install` gives me the following error:
```
npm ERR! prepareGitDep 1> 
npm ERR! prepareGitDep > locate-java-home@1.1.2 prepare /home/fpoli/.npm/_cacache/tmp/git-clone-ab8bcca3
npm ERR! prepareGitDep > tsc && tsc -p tsconfig.es6.json && javac -source 1.6 -target 1.6 ts/test/fixtures/EnvironmentTest.java
npm ERR! prepareGitDep 
npm ERR! prepareGitDep 
npm ERR! prepareGitDep 2> npm WARN install Usage of the `--dev` option is deprecated. Use `--also=dev` instead.
npm ERR! prepareGitDep warning: [options] bootstrap class path not set in conjunction with -source 6
npm ERR! prepareGitDep error: Source option 6 is no longer supported. Use 7 or later.
npm ERR! prepareGitDep error: Target option 6 is no longer supported. Use 7 or later.
npm ERR! prepareGitDep npm ERR! code ELIFECYCLE
npm ERR! prepareGitDep npm ERR! errno 2
npm ERR! prepareGitDep npm ERR! locate-java-home@1.1.2 prepare: `tsc && tsc -p tsconfig.es6.json && javac -source 1.6 -target 1.6 ts/test/fixtures/EnvironmentTest.java`
npm ERR! prepareGitDep npm ERR! Exit status 2
npm ERR! prepareGitDep npm ERR! 
npm ERR! prepareGitDep npm ERR! Failed at the locate-java-home@1.1.2 prepare script.
npm ERR! prepareGitDep npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm ERR! prepareGitDep 
npm ERR! prepareGitDep npm ERR! A complete log of this run can be found in:
npm ERR! prepareGitDep npm ERR!     /home/fpoli/.npm/_logs/2021-01-05T12_54_00_721Z-debug.log
npm ERR! prepareGitDep 
npm ERR! premature close
```